### PR TITLE
Track hardware/xiaomi from LOS

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -39,6 +39,7 @@
   <project path="hardware/qcom-caf/thermal" name="android_hardware_qcom_thermal" remote="lineage" />
   <project path="hardware/qcom-caf/vr" name="android_hardware_qcom_vr" remote="lineage" />
   <project path="hardware/qcom-caf/wlan" name="android_hardware_qcom_wlan" remote="lineage" revision="lineage-17.1-caf" />
+  <project path="hardware/xiaomi" name="android_hardware_xiaomi" remote="lineage" />
 
   <!-- Packages -->
   <project path="packages/apps/CellBroadcastReceiver" name="android_packages_apps_CellBroadcastReceiver" remote="lineage" />


### PR DESCRIPTION
Since branch:11 has it tracked to, why not for branch:10?