### PR TITLE
Track proton-clang from kdrag0n/proton-clang

### DIFF
--- a/snippets/nad.xml
+++ b/snippets/nad.xml
@@ -150,6 +150,7 @@
   <project path="prebuilts/build-tools" name="android_prebuilts_build-tools" remote="nad" />
   <project path="prebuilts/abi-dumps/ndk" name="android_prebuilts_abi-dumps_ndk" remote="nad" clone-depth="1" />
   <project path="prebuilts/abi-dumps/vndk" name="android_prebuilts_abi-dumps_vndk" remote="nad" clone-depth="1" />
+  <project path="prebuilts/clang/host/linux-x86/clang-proton" name="kdrag0n/proton-clang" remote="github" revision="master" clone-depth="1" />
   <!--project path="prebuilts/prebuiltapks" name="android_prebuilts_prebuiltapks" remote="nad" revision="10" /-->
 
   <!-- Packages -->


### PR DESCRIPTION
Why not?  If 11 Repo has it