### PR TITLE
Fix URL for vendor_google_gms

### DIFF
--- a/snippets/nusantara.xml
+++ b/snippets/nusantara.xml
@@ -150,7 +150,7 @@
   <project path="vendor/qcom/opensource/power" name="android_vendor_qcom_opensource_power" remote="nad" />
   <project path="vendor/qcom/opensource/fm-commonsys" name="android_vendor_qcom_opensource_fm-commonsys" remote="nad" />
   <project path="vendor/qcom/opensource/vibrator" name="android_vendor_qcom_opensource_vibrator" remote="nad" />
-  <project path="vendor/google/gms" name="NusantaraProject/vendor_google_gms" remote="gitlab" revision="12-old" />
+  <project path="vendor/google/gms" name="NusantaraProject/vendor_google_gms" remote="gitlab" revision="12" />
   
   <project path="packages/modules/adb" name="android_packages_modules_adb" remote="nad" />
 </manifest>


### PR DESCRIPTION
Seems like you forgot to modify this

```xml
<project path="vendor/google/gms" name="NusantaraProject/vendor_google_gms" remote="gitlab" revision="12-old" />
```

into this

```xml
<project path="vendor/google/gms" name="NusantaraProject/vendor_google_gms" remote="gitlab" revision="12" />
```

after modified the branch name at gitlab repo. Thus, other contributors cannot sync the repo successfully. This patch fixes the problem.